### PR TITLE
Fix imports with node builtin modules

### DIFF
--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -328,7 +328,7 @@ function legacyMainResolve(packageJsonUrl, packageConfig, base) {
  */
 function finalizeResolution(resolved, base) {
   if (resolved.protocol === 'node:') {
-    return resolved;
+    return resolved
   }
 
   if (encodedSepRegEx.test(resolved.pathname))
@@ -461,7 +461,7 @@ function resolvePackageTargetString(
     throwInvalidPackageTarget(match, target, packageJsonUrl, internal, base)
 
   if (builtins().includes(target)) {
-    return new URL(`node:${target}`);
+    return new URL(`node:${target}`)
   }
 
   if (!target.startsWith('./')) {
@@ -1069,7 +1069,7 @@ export function defaultResolve(specifier, context = {}) {
   const conditions = getConditionsSet(context.conditions)
   let url = moduleResolve(specifier, new URL(parentURL), conditions)
 
-  if (url.protocol === 'node:') return {url: `${url}`} // imports could point to a node built-in module
+  if (url.protocol === 'node:') return {url: `${url}`} // Imports could point to a node built-in module
 
   const urlPath = fileURLToPath(url)
   const real = realpathSync(urlPath)

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -327,6 +327,10 @@ function legacyMainResolve(packageJsonUrl, packageConfig, base) {
  * @returns {URL}
  */
 function finalizeResolution(resolved, base) {
+  if (resolved.protocol === 'node:') {
+    return resolved;
+  }
+
   if (encodedSepRegEx.test(resolved.pathname))
     throw new ERR_INVALID_MODULE_SPECIFIER(
       resolved.pathname,
@@ -455,6 +459,10 @@ function resolvePackageTargetString(
 ) {
   if (subpath !== '' && !pattern && target[target.length - 1] !== '/')
     throwInvalidPackageTarget(match, target, packageJsonUrl, internal, base)
+
+  if (builtins().includes(target)) {
+    return new URL(`node:${target}`);
+  }
 
   if (!target.startsWith('./')) {
     if (internal && !target.startsWith('../') && !target.startsWith('/')) {
@@ -1060,6 +1068,8 @@ export function defaultResolve(specifier, context = {}) {
 
   const conditions = getConditionsSet(context.conditions)
   let url = moduleResolve(specifier, new URL(parentURL), conditions)
+
+  if (url.protocol === 'node:') return {url: `${url}`} // imports could point to a node built-in module
 
   const urlPath = fileURLToPath(url)
   const real = realpathSync(urlPath)

--- a/test/core.js
+++ b/test/core.js
@@ -580,5 +580,14 @@ test('resolve(specifier, base?, conditions?)', async function (t) {
     process.emitWarning = oldEmitWarning
   })()
 
+  t.is(
+    await resolve(
+      '#a',
+      new URL('./node_modules/package-import-map-6/', import.meta.url).href
+    ),
+    new URL('node:net').href,
+    'should be able to resolve to a built-in node module'
+  )
+
   t.end()
 })

--- a/test/node_modules/package-import-map-6/package.json
+++ b/test/node_modules/package-import-map-6/package.json
@@ -1,0 +1,6 @@
+{
+  "type": "module",
+  "imports": {
+    "#a": "net"
+  }
+}


### PR DESCRIPTION
This fixes an inconsistency between `node`'s `import.meta.resolve` and this module's resolver.

If `package.json` contains the following:

```
{
  "imports": {
    "#a": "net"
  }
}
```

Then observe:

```js
import { resolve, moduleResolve } from 'import-meta-resolve';

console.log(await import.meta.resolve("#a", import.meta.url));
console.log(moduleResolve("#a", import.meta.url));
console.log(await resolve("#a", import.meta.url));
```

`import.meta.resolve` resolves to `node:net`, but this package throws an error.
This PR fixes the issue.

Some extra background:
I was using this feature in my [`chai-ip` module](https://github.com/dotcore64/chai-ip/blob/a38af41faaf9c4797f48a6c0dfe4ff688747f5c1/index.js#L2), where I have something like

```js
import { isIP, isIPv4, isIPv6 } from '#is-ip'; // this is 'net' in node, 'is-ip' in browsers
```

I resolve `#is-ip` differently for node and for browsers:

```json
  "imports": {
    "#is-ip": {
      "node": "net",
      "browser": "is-ip"
    }
  }
```

Wanted to show a real-life use-case for this feature