### PR TITLE
Replace `builtins` dep w/ `builtinModules`

### DIFF
--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -24,14 +24,10 @@ import {Stats, statSync, realpathSync} from 'node:fs'
 import process from 'node:process'
 import {URL, fileURLToPath, pathToFileURL} from 'node:url'
 import path from 'node:path'
-// @ts-expect-error: hush
-import builtins from 'builtins'
+import {builtinModules} from 'node:module'
 import packageJsonReader from './package-json-reader.js'
 import {defaultGetFormatWithoutErrors} from './get-format.js'
 import {codes} from './errors.js'
-
-/** @type {Array<string>} */
-const listOfBuiltins = builtins()
 
 const RegExpPrototypeSymbolReplace = RegExp.prototype[Symbol.replace]
 
@@ -989,7 +985,7 @@ function parsePackageName(specifier, base) {
  * @returns {URL}
  */
 function packageResolve(specifier, base, conditions) {
-  if (listOfBuiltins.includes(specifier)) {
+  if (builtinModules.includes(specifier)) {
     return new URL('node:' + specifier)
   }
 
@@ -1162,7 +1158,7 @@ function checkIfDisallowedImport(specifier, parsed, parsedParentURL) {
       return {url: parsed.href}
     }
 
-    if (listOfBuiltins.includes(specifier)) {
+    if (builtinModules.includes(specifier)) {
       throw new ERR_NETWORK_IMPORT_DISALLOWED(
         specifier,
         parsedParentURL,

--- a/package.json
+++ b/package.json
@@ -28,9 +28,6 @@
     "index.d.ts",
     "index.js"
   ],
-  "dependencies": {
-    "builtins": "^5.0.0"
-  },
   "devDependencies": {
     "@types/node": "^17.0.0",
     "@types/semver": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "index.d.ts",
     "index.js"
   ],
+  "dependencies": {},
   "devDependencies": {
     "@types/node": "^17.0.0",
     "@types/semver": "^7.0.0",


### PR DESCRIPTION
Fixes #7.

Per the docs, this exists in versions above: v9.3.0, v8.10.0, v6.13.0

So, this should be safe, and eliminates ~a~ _the only_ dependency! 🎉