### PR TITLE
Fix circular dependency in `lib/get-format.js`

### DIFF
--- a/lib/get-format.js
+++ b/lib/get-format.js
@@ -4,7 +4,7 @@
 
 import path from 'node:path'
 import {URL, fileURLToPath} from 'node:url'
-import {getPackageType} from './resolve.js'
+import {getPackageType} from './resolve-get-package-type.js'
 import {codes} from './errors.js'
 
 const {ERR_UNKNOWN_FILE_EXTENSION} = codes

--- a/lib/resolve-get-package-type.js
+++ b/lib/resolve-get-package-type.js
@@ -1,0 +1,23 @@
+// Manually “tree shaken” from:
+// <https://github.com/nodejs/node/blob/6668c4d/lib/internal/modules/esm/resolve.js>
+// Last checked on: Jan 6, 2023.
+//
+// This file solves a circular dependency.
+// In Node.js, `getPackageType` is in `resolve.js`.
+// `resolve.js` imports `get-format.js`, which needs `getPackageType`.
+// We split that up so that bundlers don’t fail.
+
+/**
+ * @typedef {import('./package-config.js').PackageType} PackageType
+ */
+
+import {getPackageScopeConfig} from './package-config.js'
+
+/**
+ * @param {URL} url
+ * @returns {PackageType}
+ */
+export function getPackageType(url) {
+  const packageConfig = getPackageScopeConfig(url)
+  return packageConfig.type
+}

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -5,7 +5,6 @@
 /**
  * @typedef {import('./errors.js').ErrnoException} ErrnoException
  * @typedef {import('./package-config.js').PackageConfig} PackageConfig
- * @typedef {import('./package-config.js').PackageType} PackageType
  */
 
 import assert from 'node:assert'
@@ -883,14 +882,9 @@ function packageImportsResolve(name, base, conditions) {
   throw importNotDefined(name, packageJsonUrl, base)
 }
 
-/**
- * @param {URL} url
- * @returns {PackageType}
- */
-export function getPackageType(url) {
-  const packageConfig = getPackageScopeConfig(url)
-  return packageConfig.type
-}
+// Note: In Node.js, `getPackageType` is here.
+// To prevent a circular dependency, we move it to
+// `resolve-get-package-type.js`.
 
 /**
  * @param {string} specifier


### PR DESCRIPTION
`lib/resolve.js` imports `lib/get-format.js`, which also imports `lib/resolve.js`, creating a circular dependency that can be incompatible with some transpiling tools.

This pull request moves the dependency of `lib/get-format.js`, `getPackageType` function, to a separate file, breaking the import cycle.

Resolves #12.