### PR TITLE
fix #14: make `resolve` synchronous

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,4 +21,4 @@ jobs:
           - windows-latest
         node:
           - 18
-          - latest
+          - node

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,5 +20,5 @@ jobs:
           - ubuntu-latest
           - windows-latest
         node:
-          - lts/hydrogen
-          - node
+          - 18
+          - latest

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@
 *.log
 coverage/
 /node_modules
-test/baseline.js
+test/baseline*.js
 yarn.lock

--- a/index.js
+++ b/index.js
@@ -15,11 +15,11 @@ import {defaultResolve} from './lib/resolve.js'
  * @param {string} parent
  *   The absolute parent module URL to resolve from.
  *   You should pass `import.meta.url` or something else.
- * @returns {Promise<string>}
- *   Returns a promise that resolves to a full `file:`, `data:`, or `node:` URL
+ * @returns {string}
+ *   Returns a string that resolves to a full `file:`, `data:`, or `node:` URL
  *   to the found thing.
  */
-export async function resolve(specifier, parent) {
+export function resolve(specifier, parent) {
   if (!parent) {
     throw new Error(
       'Please pass `parent`: `import-meta-resolve` cannot ponyfill that'
@@ -31,10 +31,14 @@ export async function resolve(specifier, parent) {
   } catch (error) {
     const exception = /** @type {ErrnoException} */ (error)
 
-    return exception.code === 'ERR_UNSUPPORTED_DIR_IMPORT' &&
+    if (
+      exception.code === 'ERR_UNSUPPORTED_DIR_IMPORT' &&
       typeof exception.url === 'string'
-      ? exception.url
-      : Promise.reject(error)
+    ) {
+      return exception.url
+    }
+
+    throw error
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ import {defaultResolve} from './lib/resolve.js'
  *   The absolute parent module URL to resolve from.
  *   You should pass `import.meta.url` or something else.
  * @returns {string}
- *   Returns a string that resolves to a full `file:`, `data:`, or `node:` URL
+ *   Returns a string to a full `file:`, `data:`, or `node:` URL
  *   to the found thing.
  */
 export function resolve(specifier, parent) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "import-meta-resolve",
-  "version": "3.0.0",
+  "version": "2.2.2",
   "description": "Resolve things like Node.js — ponyfill for `import.meta.resolve`",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "import-meta-resolve",
-  "version": "2.2.2",
+  "version": "3.0.0",
   "description": "Resolve things like Node.js — ponyfill for `import.meta.resolve`",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "generate": "node --conditions development script.js",
     "build": "tsc --build --clean && tsc --build && type-coverage",
     "format": "remark . -qfo && prettier . -w --loglevel warn && xo --fix",
-    "test-api": "node --experimental-import-meta-resolve test/baseline.js && node test/index.js",
+    "test-api": "node --experimental-import-meta-resolve test/baseline.js && node --experimental-import-meta-resolve test/baseline-async.js && node test/index.js",
     "test-coverage": "c8 --check-coverage --branches 75 --functions 75 --lines 75 --statements 75 --reporter lcov npm run test-api",
     "test": "npm run generate && npm run build && npm run format && npm run test-coverage"
   },

--- a/script.js
+++ b/script.js
@@ -4,7 +4,13 @@ import fs from 'node:fs/promises'
 const base = await fs.readFile(path.join('test', 'core.js'))
 
 const lines = String(base)
-  .replace(/\bresolve(?=\(|,)/g, 'import.meta.resolve')
+  .replace(/\bresolve(?=\()/g, 'await import.meta.resolve')
+  .replace(/\bresolve(?=,)/g, 'import.meta.resolve')
+  .replace(
+    /const execute = .*$/g,
+    'const execute = async (/** @type {() => Promise<void>} */ f) => f()'
+  )
+  .replace(/execute\(/g, 'await execute(async ')
   .split('\n')
 
 await fs.writeFile(path.join('test', 'baseline.js'), lines.join('\n'))

--- a/script.js
+++ b/script.js
@@ -7,10 +7,10 @@ const lines = String(base)
   .replace(/\bresolve(?=\()/g, 'await import.meta.resolve')
   .replace(/\bresolve(?=,)/g, 'import.meta.resolve')
   .replace(
-    /const execute = .*$/g,
-    'const execute = async (/** @type {() => Promise<void>} */ f) => f()'
+    /const run = .*$/g,
+    'const run = async (/** @type {() => Promise<void>} */ f) => f()'
   )
-  .replace(/execute\(/g, 'await execute(async ')
+  .replace(/run\(/g, 'await run(async ')
   .split('\n')
 
 await fs.writeFile(path.join('test', 'baseline.js'), lines.join('\n'))

--- a/script.js
+++ b/script.js
@@ -1,11 +1,10 @@
 import path from 'node:path'
 import fs from 'node:fs/promises'
 
-const base = await fs.readFile(path.join('test', 'core.js'))
+const base = await fs.readFile(path.join('test', 'core.js'), 'utf8')
 
-const lines = String(base)
-  // Changing the call from sync `resolve` to async `import.meta.resolve` because Node.js currently
-  // doesn't support synchronous `import.meta.resolve`.
+const asyncLines = base
+  // Special baseline test for Node < 20, that doesn't support sync `import.meta.resolve`
   .replace(/\bresolve(?=\()/g, 'await import.meta.resolve')
   .replace(/\bresolve(?=,)/g, 'import.meta.resolve')
   .replace(
@@ -13,6 +12,21 @@ const lines = String(base)
     'const run = async (/** @type {() => Promise<void>} */ f) => f()'
   )
   .replace(/run\(/g, 'await run(async ')
-  .split('\n')
 
-await fs.writeFile(path.join('test', 'baseline.js'), lines.join('\n'))
+await fs.writeFile(path.join('test', 'baseline-async.js'), asyncLines)
+
+const syncLines = base
+  // Node < 20 does not support sync import.meta.resolve, so skipping these tests if so
+  .replace(/\bresolve(?=\()/g, 'import.meta.resolve')
+  .replace(/\bresolve(?=,)/g, 'import.meta.resolve')
+  .replace(
+    '{skip: false}',
+    "{skip: semver.lt(process.versions.node, '20.0.0')}"
+  )
+  .replace(
+    /const run = .*$/g,
+    'const run = (/** @type {() => void} */ f) => f()'
+  )
+  .replace(/run\(/g, 'run(async ')
+
+await fs.writeFile(path.join('test', 'baseline.js'), syncLines)

--- a/script.js
+++ b/script.js
@@ -4,6 +4,8 @@ import fs from 'node:fs/promises'
 const base = await fs.readFile(path.join('test', 'core.js'))
 
 const lines = String(base)
+  // Changing the call from sync `resolve` to async `import.meta.resolve` because Node.js currently
+  // doesn't support synchronous `import.meta.resolve`.
   .replace(/\bresolve(?=\()/g, 'await import.meta.resolve')
   .replace(/\bresolve(?=,)/g, 'import.meta.resolve')
   .replace(

--- a/test/core.js
+++ b/test/core.js
@@ -16,9 +16,12 @@ const oldNode = semver.lt(process.versions.node, '18.0.0')
 const run = (/** @type {() => void} */ f) => f()
 
 process.on('exit', async () => {
+  try {
   // Has to be sync.
-  if (existsSync('package.json.bak')) {
     renameSync('package.json.bak', 'package.json')
+  } catch (/** @type {any} */ error) {
+    // ignore if not found, which will happen because baseline.js sometimes skips the test
+    if (error.code !== 'ENOENT') throw error
   }
 })
 

--- a/test/core.js
+++ b/test/core.js
@@ -14,7 +14,7 @@ const windows = process.platform === 'win32'
 const veryOldNode = semver.lt(process.versions.node, '16.0.0')
 const oldNode = semver.lt(process.versions.node, '18.0.0')
 
-const execute = (/** @type {() => void} */ f) => f()
+const run = (/** @type {() => void} */ f) => f()
 
 process.on('exit', async () => {
   // Has to be sync.
@@ -366,7 +366,7 @@ test('resolve(specifier, base?, conditions?)', async function () {
     'should be able to import CJS packages w/o `main`'
   )
 
-  execute(() => {
+  run(() => {
     assert(resolve, 'expected `resolve` to exist (needed for TS in baseline)')
 
     const oldEmitWarning = process.emitWarning
@@ -403,7 +403,7 @@ test('resolve(specifier, base?, conditions?)', async function () {
     process.emitWarning = oldEmitWarning
   })
 
-  execute(() => {
+  run(() => {
     assert(resolve, 'expected `resolve` to exist (needed for TS in baseline)')
 
     const oldEmitWarning = process.emitWarning
@@ -494,7 +494,7 @@ test('resolve(specifier, base?, conditions?)', async function () {
     )
   }
 
-  execute(() => {
+  run(() => {
     assert(resolve, 'expected `resolve` to exist (needed for TS in baseline)')
 
     const oldEmitWarning = process.emitWarning
@@ -601,7 +601,7 @@ test('resolve(specifier, base?, conditions?)', async function () {
     }
   }
 
-  execute(() => {
+  run(() => {
     assert(resolve, 'expected `resolve` to exist (needed for TS in baseline)')
 
     const oldEmitWarning = process.emitWarning

--- a/test/core.js
+++ b/test/core.js
@@ -3,7 +3,7 @@
  */
 
 import assert from 'node:assert/strict'
-import {promises as fs, renameSync, existsSync} from 'node:fs'
+import {promises as fs, renameSync} from 'node:fs'
 import process from 'node:process'
 import {URL, pathToFileURL} from 'node:url'
 import test from 'node:test'
@@ -17,7 +17,7 @@ const run = (/** @type {() => void} */ f) => f()
 
 process.on('exit', async () => {
   try {
-  // Has to be sync.
+    // Has to be sync.
     renameSync('package.json.bak', 'package.json')
   } catch (/** @type {any} */ error) {
     // ignore if not found, which will happen because baseline.js sometimes skips the test
@@ -27,6 +27,7 @@ process.on('exit', async () => {
 
 test(
   'resolve(specifier, base?, conditions?)',
+  // // Note: this is toggled by the `baseline*.js` tests (see `script.js` for details on why and how)
   {skip: false},
   async function () {
     assert(resolve, 'expected `resolve` to exist (needed for TS in baseline)')

--- a/test/core.js
+++ b/test/core.js
@@ -14,6 +14,8 @@ const windows = process.platform === 'win32'
 const veryOldNode = semver.lt(process.versions.node, '16.0.0')
 const oldNode = semver.lt(process.versions.node, '18.0.0')
 
+const execute = (/** @type {() => void} */ f) => f()
+
 process.on('exit', async () => {
   // Has to be sync.
   renameSync('package.json.bak', 'package.json')
@@ -25,7 +27,7 @@ test('resolve(specifier, base?, conditions?)', async function () {
   await fs.rename('package.json', 'package.json.bak')
 
   try {
-    await resolve('', import.meta.url)
+    resolve('', import.meta.url)
     assert.fail()
   } catch (error) {
     const exception = /** @type {ErrnoException} */ (error)
@@ -33,7 +35,7 @@ test('resolve(specifier, base?, conditions?)', async function () {
   }
 
   try {
-    await resolve('abc', import.meta.url)
+    resolve('abc', import.meta.url)
     assert.fail()
   } catch (error) {
     const exception = /** @type {ErrnoException} */ (error)
@@ -45,7 +47,7 @@ test('resolve(specifier, base?, conditions?)', async function () {
   }
 
   try {
-    await resolve('/abc', import.meta.url)
+    resolve('/abc', import.meta.url)
     assert.fail()
   } catch (error) {
     const exception = /** @type {ErrnoException} */ (error)
@@ -57,7 +59,7 @@ test('resolve(specifier, base?, conditions?)', async function () {
   }
 
   try {
-    await resolve('./abc', import.meta.url)
+    resolve('./abc', import.meta.url)
     assert.fail()
   } catch (error) {
     const exception = /** @type {ErrnoException} */ (error)
@@ -69,7 +71,7 @@ test('resolve(specifier, base?, conditions?)', async function () {
   }
 
   try {
-    await resolve('../abc', import.meta.url)
+    resolve('../abc', import.meta.url)
     assert.fail()
   } catch (error) {
     const exception = /** @type {ErrnoException} */ (error)
@@ -81,7 +83,7 @@ test('resolve(specifier, base?, conditions?)', async function () {
   }
 
   try {
-    await resolve('#', import.meta.url)
+    resolve('#', import.meta.url)
     assert.fail()
   } catch (error) {
     const exception = /** @type {ErrnoException} */ (error)
@@ -93,7 +95,7 @@ test('resolve(specifier, base?, conditions?)', async function () {
   }
 
   try {
-    await resolve('#/', import.meta.url)
+    resolve('#/', import.meta.url)
     assert.fail()
   } catch (error) {
     const exception = /** @type {ErrnoException} */ (error)
@@ -105,50 +107,50 @@ test('resolve(specifier, base?, conditions?)', async function () {
   }
 
   assert.equal(
-    await resolve('../tsconfig.json', import.meta.url),
+    resolve('../tsconfig.json', import.meta.url),
     pathToFileURL('tsconfig.json').href,
     'should resolve a json file'
   )
 
   assert.equal(
-    await resolve('./index.js', import.meta.url),
+    resolve('./index.js', import.meta.url),
     pathToFileURL('test/index.js').href,
     'should resolve a js file'
   )
 
   assert.equal(
-    await resolve('..', import.meta.url),
+    resolve('..', import.meta.url),
     pathToFileURL('../import-meta-resolve/').href,
     'should resolve a directory (1)'
   )
 
   assert.equal(
-    await resolve('../lib', import.meta.url),
+    resolve('../lib', import.meta.url),
     pathToFileURL('../import-meta-resolve/lib').href,
     'should resolve a directory (2)'
   )
 
   assert.equal(
-    await resolve('../lib/', import.meta.url),
+    resolve('../lib/', import.meta.url),
     pathToFileURL('../import-meta-resolve/lib/').href,
     'should resolve a directory (3)'
   )
 
   assert.equal(
-    await resolve('micromark', import.meta.url),
+    resolve('micromark', import.meta.url),
     new URL('../node_modules/micromark/index.js', import.meta.url).href,
     'should resolve a bare specifier to a package'
   )
 
   assert.equal(
-    await resolve('mdast-util-to-string/index.js', import.meta.url),
+    resolve('mdast-util-to-string/index.js', import.meta.url),
     new URL('../node_modules/mdast-util-to-string/index.js', import.meta.url)
       .href,
     'should resolve a bare specifier plus path'
   )
 
   assert.equal(
-    await resolve('@bcoe/v8-coverage', import.meta.url),
+    resolve('@bcoe/v8-coverage', import.meta.url),
     new URL(
       '../node_modules/@bcoe/v8-coverage/dist/lib/index.js',
       import.meta.url
@@ -157,7 +159,7 @@ test('resolve(specifier, base?, conditions?)', async function () {
   )
 
   try {
-    await resolve('xxx-missing', import.meta.url)
+    resolve('xxx-missing', import.meta.url)
     assert.fail()
   } catch (error) {
     const exception = /** @type {ErrnoException} */ (error)
@@ -169,7 +171,7 @@ test('resolve(specifier, base?, conditions?)', async function () {
   }
 
   try {
-    await resolve('@a/b', import.meta.url)
+    resolve('@a/b', import.meta.url)
     assert.fail()
   } catch (error) {
     const exception = /** @type {ErrnoException} */ (error)
@@ -181,7 +183,7 @@ test('resolve(specifier, base?, conditions?)', async function () {
   }
 
   try {
-    await resolve('@scope-only', import.meta.url)
+    resolve('@scope-only', import.meta.url)
     assert.fail()
   } catch (error) {
     const exception = /** @type {ErrnoException} */ (error)
@@ -193,7 +195,7 @@ test('resolve(specifier, base?, conditions?)', async function () {
   }
 
   try {
-    await resolve('%20', import.meta.url)
+    resolve('%20', import.meta.url)
     assert.fail()
   } catch (error) {
     const exception = /** @type {ErrnoException} */ (error)
@@ -205,7 +207,7 @@ test('resolve(specifier, base?, conditions?)', async function () {
   }
 
   try {
-    await resolve('micromark/index.js', import.meta.url)
+    resolve('micromark/index.js', import.meta.url)
     assert.fail()
   } catch (error) {
     const exception = /** @type {ErrnoException} */ (error)
@@ -217,37 +219,37 @@ test('resolve(specifier, base?, conditions?)', async function () {
   }
 
   assert.equal(
-    await resolve('micromark/stream', import.meta.url),
+    resolve('micromark/stream', import.meta.url),
     new URL('../node_modules/micromark/stream.js', import.meta.url).href,
     'should resolve a bare specifier + path which is exported'
   )
 
   assert.equal(
-    await resolve('micromark', import.meta.url),
+    resolve('micromark', import.meta.url),
     new URL('../node_modules/micromark/index.js', import.meta.url).href,
     'should cache results'
   )
 
   assert.equal(
-    await resolve('fs', import.meta.url),
+    resolve('fs', import.meta.url),
     'node:fs',
     'should support internal node modules'
   )
 
   assert.equal(
-    await resolve('node:fs', import.meta.url),
+    resolve('node:fs', import.meta.url),
     'node:fs',
     'should support `node:` protocols'
   )
 
   assert.equal(
-    await resolve('data:1', import.meta.url),
+    resolve('data:1', import.meta.url),
     'data:1',
     'should support `data:` protocols'
   )
 
   try {
-    await resolve('xss:1', import.meta.url)
+    resolve('xss:1', import.meta.url)
     assert.fail()
   } catch (error) {
     const exception = /** @type {ErrnoException} */ (error)
@@ -260,7 +262,7 @@ test('resolve(specifier, base?, conditions?)', async function () {
 
   if (!oldNode) {
     try {
-      await resolve('node:fs', 'https://example.com/file.html')
+      resolve('node:fs', 'https://example.com/file.html')
       assert.fail()
     } catch (error) {
       const exception = /** @type {ErrnoException} */ (error)
@@ -273,19 +275,19 @@ test('resolve(specifier, base?, conditions?)', async function () {
   }
 
   assert.equal(
-    await resolve('./index.js?1', import.meta.url),
+    resolve('./index.js?1', import.meta.url),
     new URL('index.js?1', import.meta.url).href,
     'should support a `search` in specifiers'
   )
 
   assert.equal(
-    await resolve('./index.js#1', import.meta.url),
+    resolve('./index.js#1', import.meta.url),
     new URL('index.js#1', import.meta.url).href,
     'should support a `hash` in specifiers'
   )
 
   try {
-    await resolve('./example.js', 'data:1')
+    resolve('./example.js', 'data:1')
     assert.fail()
   } catch (error) {
     const exception = /** @type {ErrnoException} */ (error)
@@ -299,19 +301,19 @@ test('resolve(specifier, base?, conditions?)', async function () {
   }
 
   assert.equal(
-    await resolve('./index.js', import.meta.url),
+    resolve('./index.js', import.meta.url),
     new URL('index.js', import.meta.url).href,
     'should be able to find files w/o `package.json`'
   )
 
   assert.equal(
-    await resolve('micromark', import.meta.url),
+    resolve('micromark', import.meta.url),
     new URL('../node_modules/micromark/index.js', import.meta.url).href,
     'should be able to find packages w/o `package.json`'
   )
 
   try {
-    await resolve('xxx-missing', import.meta.url)
+    resolve('xxx-missing', import.meta.url)
     assert.fail()
   } catch (error) {
     const exception = /** @type {ErrnoException} */ (error)
@@ -323,7 +325,7 @@ test('resolve(specifier, base?, conditions?)', async function () {
   }
 
   try {
-    await resolve('#local', import.meta.url)
+    resolve('#local', import.meta.url)
     assert.fail()
   } catch (error) {
     const exception = /** @type {ErrnoException} */ (error)
@@ -335,7 +337,7 @@ test('resolve(specifier, base?, conditions?)', async function () {
   }
 
   try {
-    await resolve('no-package-json', import.meta.url)
+    resolve('no-package-json', import.meta.url)
     assert.fail()
   } catch (error) {
     const exception = /** @type {ErrnoException} */ (error)
@@ -347,7 +349,7 @@ test('resolve(specifier, base?, conditions?)', async function () {
   }
 
   try {
-    await resolve('package-no-main', import.meta.url)
+    resolve('package-no-main', import.meta.url)
     assert.fail()
   } catch (error) {
     const exception = /** @type {ErrnoException} */ (error)
@@ -359,12 +361,12 @@ test('resolve(specifier, base?, conditions?)', async function () {
   }
 
   assert.equal(
-    await resolve('package-no-main-2', import.meta.url),
+    resolve('package-no-main-2', import.meta.url),
     new URL('node_modules/package-no-main-2/index.js', import.meta.url).href,
     'should be able to import CJS packages w/o `main`'
   )
 
-  await (async () => {
+  execute(() => {
     assert(resolve, 'expected `resolve` to exist (needed for TS in baseline)')
 
     const oldEmitWarning = process.emitWarning
@@ -383,7 +385,7 @@ test('resolve(specifier, base?, conditions?)', async function () {
       }
 
     assert.equal(
-      await resolve('package-no-main-3', import.meta.url),
+      resolve('package-no-main-3', import.meta.url),
       new URL('node_modules/package-no-main-3/index.js', import.meta.url).href,
       'should be able to import ESM packages w/o `main`, but warn (1)'
     )
@@ -399,9 +401,9 @@ test('resolve(specifier, base?, conditions?)', async function () {
     }
 
     process.emitWarning = oldEmitWarning
-  })()
+  })
 
-  await (async () => {
+  execute(() => {
     assert(resolve, 'expected `resolve` to exist (needed for TS in baseline)')
 
     const oldEmitWarning = process.emitWarning
@@ -420,7 +422,7 @@ test('resolve(specifier, base?, conditions?)', async function () {
       }
 
     assert.equal(
-      await resolve('package-no-main-4', import.meta.url),
+      resolve('package-no-main-4', import.meta.url),
       new URL('node_modules/package-no-main-4/index.js', import.meta.url).href,
       'should be able to import ESM packages w/ non-full `main`, but warn (1)'
     )
@@ -436,10 +438,10 @@ test('resolve(specifier, base?, conditions?)', async function () {
     }
 
     process.emitWarning = oldEmitWarning
-  })()
+  })
 
   try {
-    await resolve('package-invalid-json', import.meta.url)
+    resolve('package-invalid-json', import.meta.url)
     assert.fail()
   } catch (error) {
     const exception = /** @type {ErrnoException} */ (error)
@@ -451,25 +453,25 @@ test('resolve(specifier, base?, conditions?)', async function () {
   }
 
   assert.equal(
-    await resolve('package-export-map-1/a', import.meta.url),
+    resolve('package-export-map-1/a', import.meta.url),
     new URL('node_modules/package-export-map-1/b.js', import.meta.url).href,
     'should be able to resolve to something from an export map (1)'
   )
 
   assert.equal(
-    await resolve('package-export-map-1/lib/c', import.meta.url),
+    resolve('package-export-map-1/lib/c', import.meta.url),
     new URL('node_modules/package-export-map-1/lib/c.js', import.meta.url).href,
     'should be able to resolve to something from an export map (2)'
   )
 
   assert.equal(
-    await resolve('package-export-map-2', import.meta.url),
+    resolve('package-export-map-2', import.meta.url),
     new URL('node_modules/package-export-map-2/main.js', import.meta.url).href,
     'should be able to resolve to something from a main export map'
   )
 
   try {
-    await resolve('package-export-map-2/missing', import.meta.url)
+    resolve('package-export-map-2/missing', import.meta.url)
     assert.fail()
   } catch (error) {
     const exception = /** @type {ErrnoException} */ (error)
@@ -481,7 +483,7 @@ test('resolve(specifier, base?, conditions?)', async function () {
   }
 
   try {
-    await resolve('package-export-map-4', import.meta.url)
+    resolve('package-export-map-4', import.meta.url)
     assert.fail()
   } catch (error) {
     const exception = /** @type {ErrnoException} */ (error)
@@ -492,7 +494,7 @@ test('resolve(specifier, base?, conditions?)', async function () {
     )
   }
 
-  await (async () => {
+  execute(() => {
     assert(resolve, 'expected `resolve` to exist (needed for TS in baseline)')
 
     const oldEmitWarning = process.emitWarning
@@ -515,7 +517,7 @@ test('resolve(specifier, base?, conditions?)', async function () {
       }
 
     assert.equal(
-      await resolve(
+      resolve(
         './a/',
         new URL('node_modules/package-export-map-5/', import.meta.url).href
       ),
@@ -524,7 +526,7 @@ test('resolve(specifier, base?, conditions?)', async function () {
 
     try {
       // Twice for coverage: deprecation should fire only once.
-      await resolve(
+      resolve(
         './a/b.js',
         new URL('node_modules/package-export-map-5/', import.meta.url).href
       )
@@ -532,10 +534,10 @@ test('resolve(specifier, base?, conditions?)', async function () {
     } catch {}
 
     process.emitWarning = oldEmitWarning
-  })()
+  })
 
   assert.equal(
-    await resolve(
+    resolve(
       '#a',
       new URL('node_modules/package-import-map-1/', import.meta.url).href
     ),
@@ -544,7 +546,7 @@ test('resolve(specifier, base?, conditions?)', async function () {
   )
 
   try {
-    await resolve(
+    resolve(
       '#b',
       new URL('node_modules/package-import-map-1/', import.meta.url).href
     )
@@ -559,7 +561,7 @@ test('resolve(specifier, base?, conditions?)', async function () {
   }
 
   try {
-    await resolve(
+    resolve(
       '#a',
       new URL('node_modules/package-import-map-2/', import.meta.url).href
     )
@@ -574,7 +576,7 @@ test('resolve(specifier, base?, conditions?)', async function () {
   }
 
   assert.equal(
-    await resolve(
+    resolve(
       '#a/b.js',
       new URL('node_modules/package-import-map-3/', import.meta.url).href
     ),
@@ -583,7 +585,7 @@ test('resolve(specifier, base?, conditions?)', async function () {
   )
 
   try {
-    await resolve(
+    resolve(
       '#a/b.js',
       new URL('node_modules/package-import-map-4/', import.meta.url).href
     )
@@ -599,7 +601,7 @@ test('resolve(specifier, base?, conditions?)', async function () {
     }
   }
 
-  await (async () => {
+  execute(() => {
     assert(resolve, 'expected `resolve` to exist (needed for TS in baseline)')
 
     const oldEmitWarning = process.emitWarning
@@ -619,7 +621,7 @@ test('resolve(specifier, base?, conditions?)', async function () {
       }
 
     try {
-      await resolve(
+      resolve(
         '#a/b.js',
         new URL('node_modules/package-import-map-5/', import.meta.url).href
       )
@@ -636,11 +638,11 @@ test('resolve(specifier, base?, conditions?)', async function () {
     }
 
     process.emitWarning = oldEmitWarning
-  })()
+  })
 
   if (!veryOldNode) {
     assert.equal(
-      await resolve(
+      resolve(
         '#a',
         new URL('node_modules/package-import-map-6/', import.meta.url).href
       ),
@@ -650,7 +652,7 @@ test('resolve(specifier, base?, conditions?)', async function () {
   }
 
   assert.equal(
-    await resolve(
+    resolve(
       'package-self-import-1',
       new URL('node_modules/package-self-import-1/', import.meta.url).href
     ),
@@ -660,7 +662,7 @@ test('resolve(specifier, base?, conditions?)', async function () {
   )
 
   assert.equal(
-    await resolve(
+    resolve(
       'package-self-import-1',
       new URL(
         'node_modules/package-self-import-1/test/index.js',
@@ -673,14 +675,14 @@ test('resolve(specifier, base?, conditions?)', async function () {
   )
 
   assert.equal(
-    await resolve('package-custom-extensions', import.meta.url),
+    resolve('package-custom-extensions', import.meta.url),
     new URL('node_modules/package-custom-extensions/b.ts', import.meta.url)
       .href,
     'should be able to resolve a custom `.ts` extension'
   )
 
   assert.equal(
-    await resolve('package-custom-extensions/c', import.meta.url),
+    resolve('package-custom-extensions/c', import.meta.url),
     new URL('node_modules/package-custom-extensions/d.wasm', import.meta.url)
       .href,
     'should be able to resolve a custom `.wasm` extension'

--- a/test/core.js
+++ b/test/core.js
@@ -3,7 +3,7 @@
  */
 
 import assert from 'node:assert/strict'
-import {promises as fs, renameSync} from 'node:fs'
+import {promises as fs, renameSync, existsSync} from 'node:fs'
 import process from 'node:process'
 import {URL, pathToFileURL} from 'node:url'
 import test from 'node:test'
@@ -11,619 +11,593 @@ import semver from 'semver'
 import {resolve} from '../index.js'
 
 const windows = process.platform === 'win32'
-const veryOldNode = semver.lt(process.versions.node, '16.0.0')
 const oldNode = semver.lt(process.versions.node, '18.0.0')
 
 const run = (/** @type {() => void} */ f) => f()
 
 process.on('exit', async () => {
   // Has to be sync.
-  renameSync('package.json.bak', 'package.json')
+  if (existsSync('package.json.bak')) {
+    renameSync('package.json.bak', 'package.json')
+  }
 })
 
-test('resolve(specifier, base?, conditions?)', async function () {
-  assert(resolve, 'expected `resolve` to exist (needed for TS in baseline)')
+test(
+  'resolve(specifier, base?, conditions?)',
+  {skip: false},
+  async function () {
+    assert(resolve, 'expected `resolve` to exist (needed for TS in baseline)')
 
-  await fs.rename('package.json', 'package.json.bak')
+    await fs.rename('package.json', 'package.json.bak')
 
-  try {
-    resolve('', import.meta.url)
-    assert.fail()
-  } catch (error) {
-    const exception = /** @type {ErrnoException} */ (error)
-    assert.equal(exception.code, 'ERR_MODULE_NOT_FOUND', 'empty string')
-  }
-
-  try {
-    resolve('abc', import.meta.url)
-    assert.fail()
-  } catch (error) {
-    const exception = /** @type {ErrnoException} */ (error)
-    assert.equal(
-      exception.code,
-      'ERR_MODULE_NOT_FOUND',
-      'unfound bare specifier'
-    )
-  }
-
-  try {
-    resolve('/abc', import.meta.url)
-    assert.fail()
-  } catch (error) {
-    const exception = /** @type {ErrnoException} */ (error)
-    assert.equal(
-      exception.code,
-      'ERR_MODULE_NOT_FOUND',
-      'unfound absolute path'
-    )
-  }
-
-  try {
-    resolve('./abc', import.meta.url)
-    assert.fail()
-  } catch (error) {
-    const exception = /** @type {ErrnoException} */ (error)
-    assert.equal(
-      exception.code,
-      'ERR_MODULE_NOT_FOUND',
-      'unfound relative path'
-    )
-  }
-
-  try {
-    resolve('../abc', import.meta.url)
-    assert.fail()
-  } catch (error) {
-    const exception = /** @type {ErrnoException} */ (error)
-    assert.equal(
-      exception.code,
-      'ERR_MODULE_NOT_FOUND',
-      'unfound relative parental path'
-    )
-  }
-
-  try {
-    resolve('#', import.meta.url)
-    assert.fail()
-  } catch (error) {
-    const exception = /** @type {ErrnoException} */ (error)
-    assert.equal(
-      exception.code,
-      'ERR_INVALID_MODULE_SPECIFIER',
-      'empty import specifier'
-    )
-  }
-
-  try {
-    resolve('#/', import.meta.url)
-    assert.fail()
-  } catch (error) {
-    const exception = /** @type {ErrnoException} */ (error)
-    assert.equal(
-      exception.code,
-      'ERR_INVALID_MODULE_SPECIFIER',
-      'empty absolute import specifier'
-    )
-  }
-
-  assert.equal(
-    resolve('../tsconfig.json', import.meta.url),
-    pathToFileURL('tsconfig.json').href,
-    'should resolve a json file'
-  )
-
-  assert.equal(
-    resolve('./index.js', import.meta.url),
-    pathToFileURL('test/index.js').href,
-    'should resolve a js file'
-  )
-
-  assert.equal(
-    resolve('..', import.meta.url),
-    pathToFileURL('../import-meta-resolve/').href,
-    'should resolve a directory (1)'
-  )
-
-  assert.equal(
-    resolve('../lib', import.meta.url),
-    pathToFileURL('../import-meta-resolve/lib').href,
-    'should resolve a directory (2)'
-  )
-
-  assert.equal(
-    resolve('../lib/', import.meta.url),
-    pathToFileURL('../import-meta-resolve/lib/').href,
-    'should resolve a directory (3)'
-  )
-
-  assert.equal(
-    resolve('micromark', import.meta.url),
-    new URL('../node_modules/micromark/index.js', import.meta.url).href,
-    'should resolve a bare specifier to a package'
-  )
-
-  assert.equal(
-    resolve('mdast-util-to-string/index.js', import.meta.url),
-    new URL('../node_modules/mdast-util-to-string/index.js', import.meta.url)
-      .href,
-    'should resolve a bare specifier plus path'
-  )
-
-  assert.equal(
-    resolve('@bcoe/v8-coverage', import.meta.url),
-    new URL(
-      '../node_modules/@bcoe/v8-coverage/dist/lib/index.js',
-      import.meta.url
-    ).href,
-    'should resolve a bare specifier w/ scope to a package'
-  )
-
-  try {
-    resolve('xxx-missing', import.meta.url)
-    assert.fail()
-  } catch (error) {
-    const exception = /** @type {ErrnoException} */ (error)
-    assert.equal(
-      exception.code,
-      'ERR_MODULE_NOT_FOUND',
-      'missing bare specifier'
-    )
-  }
-
-  try {
-    resolve('@a/b', import.meta.url)
-    assert.fail()
-  } catch (error) {
-    const exception = /** @type {ErrnoException} */ (error)
-    assert.equal(
-      exception.code,
-      'ERR_MODULE_NOT_FOUND',
-      'missing scoped bare specifier'
-    )
-  }
-
-  try {
-    resolve('@scope-only', import.meta.url)
-    assert.fail()
-  } catch (error) {
-    const exception = /** @type {ErrnoException} */ (error)
-    assert.equal(
-      exception.code,
-      'ERR_INVALID_MODULE_SPECIFIER',
-      'invalid scoped specifier'
-    )
-  }
-
-  try {
-    resolve('%20', import.meta.url)
-    assert.fail()
-  } catch (error) {
-    const exception = /** @type {ErrnoException} */ (error)
-    assert.equal(
-      exception.code,
-      'ERR_INVALID_MODULE_SPECIFIER',
-      'invalid package name as specifier'
-    )
-  }
-
-  try {
-    resolve('micromark/index.js', import.meta.url)
-    assert.fail()
-  } catch (error) {
-    const exception = /** @type {ErrnoException} */ (error)
-    assert.equal(
-      exception.code,
-      'ERR_PACKAGE_PATH_NOT_EXPORTED',
-      'bare specifier w/ path that’s not exported'
-    )
-  }
-
-  assert.equal(
-    resolve('micromark/stream', import.meta.url),
-    new URL('../node_modules/micromark/stream.js', import.meta.url).href,
-    'should resolve a bare specifier + path which is exported'
-  )
-
-  assert.equal(
-    resolve('micromark', import.meta.url),
-    new URL('../node_modules/micromark/index.js', import.meta.url).href,
-    'should cache results'
-  )
-
-  assert.equal(
-    resolve('fs', import.meta.url),
-    'node:fs',
-    'should support internal node modules'
-  )
-
-  assert.equal(
-    resolve('node:fs', import.meta.url),
-    'node:fs',
-    'should support `node:` protocols'
-  )
-
-  assert.equal(
-    resolve('data:1', import.meta.url),
-    'data:1',
-    'should support `data:` protocols'
-  )
-
-  try {
-    resolve('xss:1', import.meta.url)
-    assert.fail()
-  } catch (error) {
-    const exception = /** @type {ErrnoException} */ (error)
-    assert.equal(
-      exception.code,
-      'ERR_UNSUPPORTED_ESM_URL_SCHEME',
-      'should not support other protocols'
-    )
-  }
-
-  if (!oldNode) {
     try {
-      resolve('node:fs', 'https://example.com/file.html')
+      resolve('', import.meta.url)
+      assert.fail()
+    } catch (error) {
+      const exception = /** @type {ErrnoException} */ (error)
+      assert.equal(exception.code, 'ERR_MODULE_NOT_FOUND', 'empty string')
+    }
+
+    try {
+      resolve('abc', import.meta.url)
       assert.fail()
     } catch (error) {
       const exception = /** @type {ErrnoException} */ (error)
       assert.equal(
         exception.code,
-        'ERR_NETWORK_IMPORT_DISALLOWED',
-        'should not support loading builtins from http'
+        'ERR_MODULE_NOT_FOUND',
+        'unfound bare specifier'
       )
     }
-  }
 
-  assert.equal(
-    resolve('./index.js?1', import.meta.url),
-    new URL('index.js?1', import.meta.url).href,
-    'should support a `search` in specifiers'
-  )
-
-  assert.equal(
-    resolve('./index.js#1', import.meta.url),
-    new URL('index.js#1', import.meta.url).href,
-    'should support a `hash` in specifiers'
-  )
-
-  try {
-    resolve('./example.js', 'data:1')
-    assert.fail()
-  } catch (error) {
-    const exception = /** @type {ErrnoException} */ (error)
-    if (!oldNode) {
+    try {
+      resolve('/abc', import.meta.url)
+      assert.fail()
+    } catch (error) {
+      const exception = /** @type {ErrnoException} */ (error)
       assert.equal(
         exception.code,
-        oldNode ? 'ERR_INVALID_URL_SCHEME' : 'ERR_INVALID_URL',
-        'should not be able to resolve relative to a `data:` parent url'
+        'ERR_MODULE_NOT_FOUND',
+        'unfound absolute path'
       )
     }
-  }
 
-  assert.equal(
-    resolve('./index.js', import.meta.url),
-    new URL('index.js', import.meta.url).href,
-    'should be able to find files w/o `package.json`'
-  )
-
-  assert.equal(
-    resolve('micromark', import.meta.url),
-    new URL('../node_modules/micromark/index.js', import.meta.url).href,
-    'should be able to find packages w/o `package.json`'
-  )
-
-  try {
-    resolve('xxx-missing', import.meta.url)
-    assert.fail()
-  } catch (error) {
-    const exception = /** @type {ErrnoException} */ (error)
-    assert.equal(
-      exception.code,
-      'ERR_MODULE_NOT_FOUND',
-      'missing packages w/o `package.json`'
-    )
-  }
-
-  try {
-    resolve('#local', import.meta.url)
-    assert.fail()
-  } catch (error) {
-    const exception = /** @type {ErrnoException} */ (error)
-    assert.equal(
-      exception.code,
-      'ERR_PACKAGE_IMPORT_NOT_DEFINED',
-      'missing import map w/o `package.json`'
-    )
-  }
-
-  try {
-    resolve('no-package-json', import.meta.url)
-    assert.fail()
-  } catch (error) {
-    const exception = /** @type {ErrnoException} */ (error)
-    assert.equal(
-      exception.code,
-      'ERR_MODULE_NOT_FOUND',
-      'should not be able to import packages that themselves don’t have `package.json`s (1)'
-    )
-  }
-
-  try {
-    resolve('package-no-main', import.meta.url)
-    assert.fail()
-  } catch (error) {
-    const exception = /** @type {ErrnoException} */ (error)
-    assert.equal(
-      exception.code,
-      'ERR_MODULE_NOT_FOUND',
-      'should not be able to import packages w/o index files'
-    )
-  }
-
-  assert.equal(
-    resolve('package-no-main-2', import.meta.url),
-    new URL('node_modules/package-no-main-2/index.js', import.meta.url).href,
-    'should be able to import CJS packages w/o `main`'
-  )
-
-  run(() => {
-    assert(resolve, 'expected `resolve` to exist (needed for TS in baseline)')
-
-    const oldEmitWarning = process.emitWarning
-    /** @type {string|undefined} */
-    let deprecation
-
-    // @ts-expect-error hush
-    process.emitWarning =
-      /**
-       * @param {unknown} _1
-       * @param {unknown} _2
-       * @param {string} code
-       */
-      (_1, _2, code) => {
-        deprecation = code
-      }
-
-    assert.equal(
-      resolve('package-no-main-3', import.meta.url),
-      new URL('node_modules/package-no-main-3/index.js', import.meta.url).href,
-      'should be able to import ESM packages w/o `main`, but warn (1)'
-    )
-
-    if (oldNode) {
-      // Empty.
-    } else {
+    try {
+      resolve('./abc', import.meta.url)
+      assert.fail()
+    } catch (error) {
+      const exception = /** @type {ErrnoException} */ (error)
       assert.equal(
-        deprecation,
-        'DEP0151',
-        'should be able to import ESM packages w/o `main`, but warn (2)'
+        exception.code,
+        'ERR_MODULE_NOT_FOUND',
+        'unfound relative path'
       )
     }
 
-    process.emitWarning = oldEmitWarning
-  })
-
-  run(() => {
-    assert(resolve, 'expected `resolve` to exist (needed for TS in baseline)')
-
-    const oldEmitWarning = process.emitWarning
-    /** @type {string|undefined} */
-    let deprecation
-
-    // @ts-expect-error hush
-    process.emitWarning =
-      /**
-       * @param {unknown} _1
-       * @param {unknown} _2
-       * @param {string} code
-       */
-      (_1, _2, code) => {
-        deprecation = code
-      }
-
-    assert.equal(
-      resolve('package-no-main-4', import.meta.url),
-      new URL('node_modules/package-no-main-4/index.js', import.meta.url).href,
-      'should be able to import ESM packages w/ non-full `main`, but warn (1)'
-    )
-
-    if (oldNode) {
-      // Empty.
-    } else {
+    try {
+      resolve('../abc', import.meta.url)
+      assert.fail()
+    } catch (error) {
+      const exception = /** @type {ErrnoException} */ (error)
       assert.equal(
-        deprecation,
-        'DEP0151',
-        'should be able to import ESM packages w/ non-full `main`, but warn (2)'
+        exception.code,
+        'ERR_MODULE_NOT_FOUND',
+        'unfound relative parental path'
       )
     }
 
-    process.emitWarning = oldEmitWarning
-  })
+    try {
+      resolve('#', import.meta.url)
+      assert.fail()
+    } catch (error) {
+      const exception = /** @type {ErrnoException} */ (error)
+      assert.equal(
+        exception.code,
+        'ERR_INVALID_MODULE_SPECIFIER',
+        'empty import specifier'
+      )
+    }
 
-  try {
-    resolve('package-invalid-json', import.meta.url)
-    assert.fail()
-  } catch (error) {
-    const exception = /** @type {ErrnoException} */ (error)
+    try {
+      resolve('#/', import.meta.url)
+      assert.fail()
+    } catch (error) {
+      const exception = /** @type {ErrnoException} */ (error)
+      assert.equal(
+        exception.code,
+        'ERR_INVALID_MODULE_SPECIFIER',
+        'empty absolute import specifier'
+      )
+    }
+
     assert.equal(
-      exception.code,
-      'ERR_INVALID_PACKAGE_CONFIG',
-      'should not be able to import packages w/ broken `package.json`s'
+      resolve('../tsconfig.json', import.meta.url),
+      pathToFileURL('tsconfig.json').href,
+      'should resolve a json file'
     )
-  }
 
-  assert.equal(
-    resolve('package-export-map-1/a', import.meta.url),
-    new URL('node_modules/package-export-map-1/b.js', import.meta.url).href,
-    'should be able to resolve to something from an export map (1)'
-  )
-
-  assert.equal(
-    resolve('package-export-map-1/lib/c', import.meta.url),
-    new URL('node_modules/package-export-map-1/lib/c.js', import.meta.url).href,
-    'should be able to resolve to something from an export map (2)'
-  )
-
-  assert.equal(
-    resolve('package-export-map-2', import.meta.url),
-    new URL('node_modules/package-export-map-2/main.js', import.meta.url).href,
-    'should be able to resolve to something from a main export map'
-  )
-
-  try {
-    resolve('package-export-map-2/missing', import.meta.url)
-    assert.fail()
-  } catch (error) {
-    const exception = /** @type {ErrnoException} */ (error)
     assert.equal(
-      exception.code,
-      'ERR_PACKAGE_PATH_NOT_EXPORTED',
-      'should not be able to import things not in an export map'
+      resolve('./index.js', import.meta.url),
+      pathToFileURL('test/index.js').href,
+      'should resolve a js file'
     )
-  }
 
-  try {
-    resolve('package-export-map-4', import.meta.url)
-    assert.fail()
-  } catch (error) {
-    const exception = /** @type {ErrnoException} */ (error)
     assert.equal(
-      exception.code,
-      'ERR_PACKAGE_PATH_NOT_EXPORTED',
-      'should not be able to import things from an empty export map'
+      resolve('..', import.meta.url),
+      pathToFileURL('../import-meta-resolve/').href,
+      'should resolve a directory (1)'
     )
-  }
-
-  run(() => {
-    assert(resolve, 'expected `resolve` to exist (needed for TS in baseline)')
-
-    const oldEmitWarning = process.emitWarning
-    /** @type {string} */
-    let deprecation
-
-    // Windows doesn’t like `/` as a final path separator here.
-    if (windows) return
-
-    // @ts-expect-error hush
-    process.emitWarning =
-      /**
-       * @param {unknown} _1
-       * @param {unknown} _2
-       * @param {string} code
-       */
-      (_1, _2, code) => {
-        if (deprecation) assert.fail()
-        deprecation = code
-      }
 
     assert.equal(
-      resolve(
-        './a/',
-        new URL('node_modules/package-export-map-5/', import.meta.url).href
-      ),
-      new URL('node_modules/package-export-map-5/a/', import.meta.url).href
+      resolve('../lib', import.meta.url),
+      pathToFileURL('../import-meta-resolve/lib').href,
+      'should resolve a directory (2)'
+    )
+
+    assert.equal(
+      resolve('../lib/', import.meta.url),
+      pathToFileURL('../import-meta-resolve/lib/').href,
+      'should resolve a directory (3)'
+    )
+
+    assert.equal(
+      resolve('micromark', import.meta.url),
+      new URL('../node_modules/micromark/index.js', import.meta.url).href,
+      'should resolve a bare specifier to a package'
+    )
+
+    assert.equal(
+      resolve('mdast-util-to-string/index.js', import.meta.url),
+      new URL('../node_modules/mdast-util-to-string/index.js', import.meta.url)
+        .href,
+      'should resolve a bare specifier plus path'
+    )
+
+    assert.equal(
+      resolve('@bcoe/v8-coverage', import.meta.url),
+      new URL(
+        '../node_modules/@bcoe/v8-coverage/dist/lib/index.js',
+        import.meta.url
+      ).href,
+      'should resolve a bare specifier w/ scope to a package'
     )
 
     try {
-      // Twice for coverage: deprecation should fire only once.
-      resolve(
-        './a/b.js',
-        new URL('node_modules/package-export-map-5/', import.meta.url).href
-      )
+      resolve('xxx-missing', import.meta.url)
       assert.fail()
-    } catch {}
+    } catch (error) {
+      const exception = /** @type {ErrnoException} */ (error)
+      assert.equal(
+        exception.code,
+        'ERR_MODULE_NOT_FOUND',
+        'missing bare specifier'
+      )
+    }
 
-    process.emitWarning = oldEmitWarning
-  })
+    try {
+      resolve('@a/b', import.meta.url)
+      assert.fail()
+    } catch (error) {
+      const exception = /** @type {ErrnoException} */ (error)
+      assert.equal(
+        exception.code,
+        'ERR_MODULE_NOT_FOUND',
+        'missing scoped bare specifier'
+      )
+    }
 
-  assert.equal(
-    resolve(
-      '#a',
-      new URL('node_modules/package-import-map-1/', import.meta.url).href
-    ),
-    new URL('node_modules/package-import-map-1/index.js', import.meta.url).href,
-    'should be able to resolve to something from a main export map w/ package name'
-  )
+    try {
+      resolve('@scope-only', import.meta.url)
+      assert.fail()
+    } catch (error) {
+      const exception = /** @type {ErrnoException} */ (error)
+      assert.equal(
+        exception.code,
+        'ERR_INVALID_MODULE_SPECIFIER',
+        'invalid scoped specifier'
+      )
+    }
 
-  try {
-    resolve(
-      '#b',
-      new URL('node_modules/package-import-map-1/', import.meta.url).href
-    )
-    assert.fail()
-  } catch (error) {
-    const exception = /** @type {ErrnoException} */ (error)
+    try {
+      resolve('%20', import.meta.url)
+      assert.fail()
+    } catch (error) {
+      const exception = /** @type {ErrnoException} */ (error)
+      assert.equal(
+        exception.code,
+        'ERR_INVALID_MODULE_SPECIFIER',
+        'invalid package name as specifier'
+      )
+    }
+
+    try {
+      resolve('micromark/index.js', import.meta.url)
+      assert.fail()
+    } catch (error) {
+      const exception = /** @type {ErrnoException} */ (error)
+      assert.equal(
+        exception.code,
+        'ERR_PACKAGE_PATH_NOT_EXPORTED',
+        'bare specifier w/ path that’s not exported'
+      )
+    }
+
     assert.equal(
-      exception.code,
-      'ERR_PACKAGE_IMPORT_NOT_DEFINED',
-      'should not be able to import things not in an import map'
+      resolve('micromark/stream', import.meta.url),
+      new URL('../node_modules/micromark/stream.js', import.meta.url).href,
+      'should resolve a bare specifier + path which is exported'
     )
-  }
 
-  try {
-    resolve(
-      '#a',
-      new URL('node_modules/package-import-map-2/', import.meta.url).href
-    )
-    assert.fail()
-  } catch (error) {
-    const exception = /** @type {ErrnoException} */ (error)
     assert.equal(
-      exception.code,
-      'ERR_PACKAGE_IMPORT_NOT_DEFINED',
-      'should not be able to import things not in an import map incorrectly defined w/o `#`'
+      resolve('micromark', import.meta.url),
+      new URL('../node_modules/micromark/index.js', import.meta.url).href,
+      'should cache results'
     )
-  }
 
-  assert.equal(
-    resolve(
-      '#a/b.js',
-      new URL('node_modules/package-import-map-3/', import.meta.url).href
-    ),
-    new URL('node_modules/package-import-map-3/index.js', import.meta.url).href,
-    'should be able to resolve to something to import map splats'
-  )
-
-  try {
-    resolve(
-      '#a/b.js',
-      new URL('node_modules/package-import-map-4/', import.meta.url).href
+    assert.equal(
+      resolve('fs', import.meta.url),
+      'node:fs',
+      'should support internal node modules'
     )
-    assert.fail()
-  } catch (error) {
-    const exception = /** @type {ErrnoException} */ (error)
+
+    assert.equal(
+      resolve('node:fs', import.meta.url),
+      'node:fs',
+      'should support `node:` protocols'
+    )
+
+    assert.equal(
+      resolve('data:1', import.meta.url),
+      'data:1',
+      'should support `data:` protocols'
+    )
+
+    try {
+      resolve('xss:1', import.meta.url)
+      assert.fail()
+    } catch (error) {
+      const exception = /** @type {ErrnoException} */ (error)
+      assert.equal(
+        exception.code,
+        'ERR_UNSUPPORTED_ESM_URL_SCHEME',
+        'should not support other protocols'
+      )
+    }
+
     if (!oldNode) {
+      try {
+        resolve('node:fs', 'https://example.com/file.html')
+        assert.fail()
+      } catch (error) {
+        const exception = /** @type {ErrnoException} */ (error)
+        assert.equal(
+          exception.code,
+          'ERR_NETWORK_IMPORT_DISALLOWED',
+          'should not support loading builtins from http'
+        )
+      }
+    }
+
+    assert.equal(
+      resolve('./index.js?1', import.meta.url),
+      new URL('index.js?1', import.meta.url).href,
+      'should support a `search` in specifiers'
+    )
+
+    assert.equal(
+      resolve('./index.js#1', import.meta.url),
+      new URL('index.js#1', import.meta.url).href,
+      'should support a `hash` in specifiers'
+    )
+
+    try {
+      resolve('./example.js', 'data:1')
+      assert.fail()
+    } catch (error) {
+      const exception = /** @type {ErrnoException} */ (error)
+      if (!oldNode) {
+        assert.equal(
+          exception.code,
+          oldNode ? 'ERR_INVALID_URL_SCHEME' : 'ERR_INVALID_URL',
+          'should not be able to resolve relative to a `data:` parent url'
+        )
+      }
+    }
+
+    assert.equal(
+      resolve('./index.js', import.meta.url),
+      new URL('index.js', import.meta.url).href,
+      'should be able to find files w/o `package.json`'
+    )
+
+    assert.equal(
+      resolve('micromark', import.meta.url),
+      new URL('../node_modules/micromark/index.js', import.meta.url).href,
+      'should be able to find packages w/o `package.json`'
+    )
+
+    try {
+      resolve('xxx-missing', import.meta.url)
+      assert.fail()
+    } catch (error) {
+      const exception = /** @type {ErrnoException} */ (error)
+      assert.equal(
+        exception.code,
+        'ERR_MODULE_NOT_FOUND',
+        'missing packages w/o `package.json`'
+      )
+    }
+
+    try {
+      resolve('#local', import.meta.url)
+      assert.fail()
+    } catch (error) {
+      const exception = /** @type {ErrnoException} */ (error)
       assert.equal(
         exception.code,
         'ERR_PACKAGE_IMPORT_NOT_DEFINED',
-        'should not be able to import an invalid import package target'
+        'missing import map w/o `package.json`'
       )
     }
-  }
 
-  run(() => {
-    assert(resolve, 'expected `resolve` to exist (needed for TS in baseline)')
+    try {
+      resolve('no-package-json', import.meta.url)
+      assert.fail()
+    } catch (error) {
+      const exception = /** @type {ErrnoException} */ (error)
+      assert.equal(
+        exception.code,
+        'ERR_MODULE_NOT_FOUND',
+        'should not be able to import packages that themselves don’t have `package.json`s (1)'
+      )
+    }
 
-    const oldEmitWarning = process.emitWarning
-    /** @type {string|undefined} */
-    let deprecation
+    try {
+      resolve('package-no-main', import.meta.url)
+      assert.fail()
+    } catch (error) {
+      const exception = /** @type {ErrnoException} */ (error)
+      assert.equal(
+        exception.code,
+        'ERR_MODULE_NOT_FOUND',
+        'should not be able to import packages w/o index files'
+      )
+    }
 
-    // @ts-expect-error hush
-    process.emitWarning =
-      /**
-       * @param {unknown} _1
-       * @param {unknown} _2
-       * @param {string} code
-       */
-      (_1, _2, code) => {
-        if (deprecation) assert.fail()
-        deprecation = code
+    assert.equal(
+      resolve('package-no-main-2', import.meta.url),
+      new URL('node_modules/package-no-main-2/index.js', import.meta.url).href,
+      'should be able to import CJS packages w/o `main`'
+    )
+
+    run(() => {
+      assert(resolve, 'expected `resolve` to exist (needed for TS in baseline)')
+
+      const oldEmitWarning = process.emitWarning
+      /** @type {string|undefined} */
+      let deprecation
+
+      // @ts-expect-error hush
+      process.emitWarning =
+        /**
+         * @param {unknown} _1
+         * @param {unknown} _2
+         * @param {string} code
+         */
+        (_1, _2, code) => {
+          deprecation = code
+        }
+
+      assert.equal(
+        resolve('package-no-main-3', import.meta.url),
+        new URL('node_modules/package-no-main-3/index.js', import.meta.url)
+          .href,
+        'should be able to import ESM packages w/o `main`, but warn (1)'
+      )
+
+      if (oldNode) {
+        // Empty.
+      } else {
+        assert.equal(
+          deprecation,
+          'DEP0151',
+          'should be able to import ESM packages w/o `main`, but warn (2)'
+        )
       }
+
+      process.emitWarning = oldEmitWarning
+    })
+
+    run(() => {
+      assert(resolve, 'expected `resolve` to exist (needed for TS in baseline)')
+
+      const oldEmitWarning = process.emitWarning
+      /** @type {string|undefined} */
+      let deprecation
+
+      // @ts-expect-error hush
+      process.emitWarning =
+        /**
+         * @param {unknown} _1
+         * @param {unknown} _2
+         * @param {string} code
+         */
+        (_1, _2, code) => {
+          deprecation = code
+        }
+
+      assert.equal(
+        resolve('package-no-main-4', import.meta.url),
+        new URL('node_modules/package-no-main-4/index.js', import.meta.url)
+          .href,
+        'should be able to import ESM packages w/ non-full `main`, but warn (1)'
+      )
+
+      if (oldNode) {
+        // Empty.
+      } else {
+        assert.equal(
+          deprecation,
+          'DEP0151',
+          'should be able to import ESM packages w/ non-full `main`, but warn (2)'
+        )
+      }
+
+      process.emitWarning = oldEmitWarning
+    })
+
+    try {
+      resolve('package-invalid-json', import.meta.url)
+      assert.fail()
+    } catch (error) {
+      const exception = /** @type {ErrnoException} */ (error)
+      assert.equal(
+        exception.code,
+        'ERR_INVALID_PACKAGE_CONFIG',
+        'should not be able to import packages w/ broken `package.json`s'
+      )
+    }
+
+    assert.equal(
+      resolve('package-export-map-1/a', import.meta.url),
+      new URL('node_modules/package-export-map-1/b.js', import.meta.url).href,
+      'should be able to resolve to something from an export map (1)'
+    )
+
+    assert.equal(
+      resolve('package-export-map-1/lib/c', import.meta.url),
+      new URL('node_modules/package-export-map-1/lib/c.js', import.meta.url)
+        .href,
+      'should be able to resolve to something from an export map (2)'
+    )
+
+    assert.equal(
+      resolve('package-export-map-2', import.meta.url),
+      new URL('node_modules/package-export-map-2/main.js', import.meta.url)
+        .href,
+      'should be able to resolve to something from a main export map'
+    )
+
+    try {
+      resolve('package-export-map-2/missing', import.meta.url)
+      assert.fail()
+    } catch (error) {
+      const exception = /** @type {ErrnoException} */ (error)
+      assert.equal(
+        exception.code,
+        'ERR_PACKAGE_PATH_NOT_EXPORTED',
+        'should not be able to import things not in an export map'
+      )
+    }
+
+    try {
+      resolve('package-export-map-4', import.meta.url)
+      assert.fail()
+    } catch (error) {
+      const exception = /** @type {ErrnoException} */ (error)
+      assert.equal(
+        exception.code,
+        'ERR_PACKAGE_PATH_NOT_EXPORTED',
+        'should not be able to import things from an empty export map'
+      )
+    }
+
+    run(() => {
+      assert(resolve, 'expected `resolve` to exist (needed for TS in baseline)')
+
+      const oldEmitWarning = process.emitWarning
+      /** @type {string} */
+      let deprecation
+
+      // Windows doesn’t like `/` as a final path separator here.
+      if (windows) return
+
+      // @ts-expect-error hush
+      process.emitWarning =
+        /**
+         * @param {unknown} _1
+         * @param {unknown} _2
+         * @param {string} code
+         */
+        (_1, _2, code) => {
+          if (deprecation) assert.fail()
+          deprecation = code
+        }
+
+      assert.equal(
+        resolve(
+          './a/',
+          new URL('node_modules/package-export-map-5/', import.meta.url).href
+        ),
+        new URL('node_modules/package-export-map-5/a/', import.meta.url).href
+      )
+
+      try {
+        // Twice for coverage: deprecation should fire only once.
+        resolve(
+          './a/b.js',
+          new URL('node_modules/package-export-map-5/', import.meta.url).href
+        )
+        assert.fail()
+      } catch {}
+
+      process.emitWarning = oldEmitWarning
+    })
+
+    assert.equal(
+      resolve(
+        '#a',
+        new URL('node_modules/package-import-map-1/', import.meta.url).href
+      ),
+      new URL('node_modules/package-import-map-1/index.js', import.meta.url)
+        .href,
+      'should be able to resolve to something from a main export map w/ package name'
+    )
+
+    try {
+      resolve(
+        '#b',
+        new URL('node_modules/package-import-map-1/', import.meta.url).href
+      )
+      assert.fail()
+    } catch (error) {
+      const exception = /** @type {ErrnoException} */ (error)
+      assert.equal(
+        exception.code,
+        'ERR_PACKAGE_IMPORT_NOT_DEFINED',
+        'should not be able to import things not in an import map'
+      )
+    }
+
+    try {
+      resolve(
+        '#a',
+        new URL('node_modules/package-import-map-2/', import.meta.url).href
+      )
+      assert.fail()
+    } catch (error) {
+      const exception = /** @type {ErrnoException} */ (error)
+      assert.equal(
+        exception.code,
+        'ERR_PACKAGE_IMPORT_NOT_DEFINED',
+        'should not be able to import things not in an import map incorrectly defined w/o `#`'
+      )
+    }
+
+    assert.equal(
+      resolve(
+        '#a/b.js',
+        new URL('node_modules/package-import-map-3/', import.meta.url).href
+      ),
+      new URL('node_modules/package-import-map-3/index.js', import.meta.url)
+        .href,
+      'should be able to resolve to something to import map splats'
+    )
 
     try {
       resolve(
         '#a/b.js',
-        new URL('node_modules/package-import-map-5/', import.meta.url).href
+        new URL('node_modules/package-import-map-4/', import.meta.url).href
       )
       assert.fail()
     } catch (error) {
@@ -632,15 +606,50 @@ test('resolve(specifier, base?, conditions?)', async function () {
         assert.equal(
           exception.code,
           'ERR_PACKAGE_IMPORT_NOT_DEFINED',
-          'should support legacy folders in import maps (1)'
+          'should not be able to import an invalid import package target'
         )
       }
     }
 
-    process.emitWarning = oldEmitWarning
-  })
+    run(() => {
+      assert(resolve, 'expected `resolve` to exist (needed for TS in baseline)')
 
-  if (!veryOldNode) {
+      const oldEmitWarning = process.emitWarning
+      /** @type {string|undefined} */
+      let deprecation
+
+      // @ts-expect-error hush
+      process.emitWarning =
+        /**
+         * @param {unknown} _1
+         * @param {unknown} _2
+         * @param {string} code
+         */
+        (_1, _2, code) => {
+          if (deprecation) assert.fail()
+          deprecation = code
+        }
+
+      try {
+        resolve(
+          '#a/b.js',
+          new URL('node_modules/package-import-map-5/', import.meta.url).href
+        )
+        assert.fail()
+      } catch (error) {
+        const exception = /** @type {ErrnoException} */ (error)
+        if (!oldNode) {
+          assert.equal(
+            exception.code,
+            'ERR_PACKAGE_IMPORT_NOT_DEFINED',
+            'should support legacy folders in import maps (1)'
+          )
+        }
+      }
+
+      process.emitWarning = oldEmitWarning
+    })
+
     assert.equal(
       resolve(
         '#a',
@@ -649,42 +658,42 @@ test('resolve(specifier, base?, conditions?)', async function () {
       new URL('node:net').href,
       'should be able to resolve to a built-in node module'
     )
+
+    assert.equal(
+      resolve(
+        'package-self-import-1',
+        new URL('node_modules/package-self-import-1/', import.meta.url).href
+      ),
+      new URL('node_modules/package-self-import-1/index.js', import.meta.url)
+        .href,
+      'should be able to resolve a self-import'
+    )
+
+    assert.equal(
+      resolve(
+        'package-self-import-1',
+        new URL(
+          'node_modules/package-self-import-1/test/index.js',
+          import.meta.url
+        ).href
+      ),
+      new URL('node_modules/package-self-import-1/index.js', import.meta.url)
+        .href,
+      'should be able to resolve a self-import from a sub-file'
+    )
+
+    assert.equal(
+      resolve('package-custom-extensions', import.meta.url),
+      new URL('node_modules/package-custom-extensions/b.ts', import.meta.url)
+        .href,
+      'should be able to resolve a custom `.ts` extension'
+    )
+
+    assert.equal(
+      resolve('package-custom-extensions/c', import.meta.url),
+      new URL('node_modules/package-custom-extensions/d.wasm', import.meta.url)
+        .href,
+      'should be able to resolve a custom `.wasm` extension'
+    )
   }
-
-  assert.equal(
-    resolve(
-      'package-self-import-1',
-      new URL('node_modules/package-self-import-1/', import.meta.url).href
-    ),
-    new URL('node_modules/package-self-import-1/index.js', import.meta.url)
-      .href,
-    'should be able to resolve a self-import'
-  )
-
-  assert.equal(
-    resolve(
-      'package-self-import-1',
-      new URL(
-        'node_modules/package-self-import-1/test/index.js',
-        import.meta.url
-      ).href
-    ),
-    new URL('node_modules/package-self-import-1/index.js', import.meta.url)
-      .href,
-    'should be able to resolve a self-import from a sub-file'
-  )
-
-  assert.equal(
-    resolve('package-custom-extensions', import.meta.url),
-    new URL('node_modules/package-custom-extensions/b.ts', import.meta.url)
-      .href,
-    'should be able to resolve a custom `.ts` extension'
-  )
-
-  assert.equal(
-    resolve('package-custom-extensions/c', import.meta.url),
-    new URL('node_modules/package-custom-extensions/d.wasm', import.meta.url)
-      .href,
-    'should be able to resolve a custom `.wasm` extension'
-  )
-})
+)

--- a/test/ponyfill.js
+++ b/test/ponyfill.js
@@ -2,10 +2,10 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import {resolve} from '../index.js'
 
-test('ponyfill', async function () {
+test('ponyfill', function () {
   try {
     // @ts-expect-error
-    await resolve('x')
+    resolve('x')
     assert.fail()
   } catch (error) {
     assert.equal(


### PR DESCRIPTION
As described in issue #14, `import.meta.resolve` is becoming synchronous both in the browser and in Node.js:

You can see it here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import.meta/resolve

And also in Node.js, where a PR just changed it to be synchronous: nodejs/node#44710

This PR makes `resolve` synchronous to fit the above. 

Note that the baseline test calling `import.meta.resolve` was _not_ changed to be synchronous,
because that change will probably be  merged into Node v19, 
and so for 18 `import.meta.resolve` is still synchronous.
